### PR TITLE
Reset state on control toggle and early exit

### DIFF
--- a/custom_components/marstek_venus_ha/coordinator.py
+++ b/custom_components/marstek_venus_ha/coordinator.py
@@ -775,6 +775,7 @@ class MarstekCoordinator:
             except Exception:
                 pass
         self._unsub_listeners.clear()
+        self._service_call_cache.clear()
 
         if self._update_task is not None and not self._update_task.done():
             self._update_task.cancel()
@@ -796,6 +797,14 @@ class MarstekCoordinator:
     async def _async_update(self, now=None):
         """Fetch new data and run the logic."""
         # Note: logging is handled by _run_update to include a reason.
+
+        # Early exit if control is disabled, to avoid unnecessary processing and to ensure batteries are set to 0W immediately when user disables control.
+        if not self._control_enabled:
+            self._battery_priority = []
+            self._last_power_direction = PowerDir.NEUTRAL
+            # Optional: Alles auf 0 setzen zur Sicherheit
+            await self._set_all_batteries_to_zero()
+            return
 
         # Net grid power (import/export). This is the signal PID should drive towards 0W.
         smoothed_grid_power = self._get_smoothed_grid_power()
@@ -1328,10 +1337,9 @@ class MarstekCoordinator:
                     # Wenn es nicht der erste Versuch ist, aber der Cooldown abgelaufen ist,
                     # wird dies als INFO geloggt, da es ein normaler Retry ist.
                     if cooldown_elapsed:
-                         _LOGGER.info(f"High surplus ({abs(real_power):.0f}W) and inactive wallbox. Cooldown elapsed. Starting pause for car (batteries to 0 for {start_delay}s).")
+                        _LOGGER.info(f"High surplus ({abs(real_power):.0f}W) and inactive wallbox. Cooldown elapsed. Starting pause for car (batteries to 0 for {start_delay}s).")
                     else: # is_first_attempt
-                         _LOGGER.info(f"High surplus ({abs(real_power):.0f}W) and wallbox just connected. Starting initial pause for car (batteries to 0 for {start_delay}s).")
-                         
+                        _LOGGER.info(f"High surplus ({abs(real_power):.0f}W) and wallbox just connected. Starting initial pause for car (batteries to 0 for {start_delay}s).")
                     self._last_wallbox_pause_attempt = now # Cooldown-Timer (für den nächsten Versuch) starten
                     self._wallbox_wait_start = now        # Start-Delay-Timer (für den aktuellen Versuch) starten
                     self._wallbox_charge_paused = True 
@@ -1354,10 +1362,10 @@ class MarstekCoordinator:
                     # Wenn es nicht der erste Versuch ist, aber der Cooldown abgelaufen ist,
                     # wird dies als INFO geloggt, da es ein normaler Retry ist.
                     if cooldown_elapsed:
-                         _LOGGER.info(f"High surplus ({abs(real_power - wb_power):.0f}W) and charging wallbox. Cooldown elapsed. Starting pause for car (batteries to 0 for {start_delay}s).")
+                        _LOGGER.info(f"High surplus ({abs(real_power - wb_power):.0f}W) and charging wallbox. Cooldown elapsed. Starting pause for car (batteries to 0 for {start_delay}s).")
                     else: # is_first_attempt
-                         _LOGGER.info(f"High surplus ({abs(real_power - wb_power):.0f}W) and wallbox just connected. Starting initial pause for car (batteries to 0 for {start_delay}s).")
-                         
+                        _LOGGER.info(f"High surplus ({abs(real_power - wb_power):.0f}W) and wallbox just connected. Starting initial pause for car (batteries to 0 for {start_delay}s).")
+
                     self._last_wallbox_pause_attempt = now # Cooldown-Timer (für den nächsten Versuch) starten
                     self._wallbox_wait_start = now        # Start-Delay-Timer (für den aktuellen Versuch) starten
                     self._wallbox_charge_paused = True
@@ -2099,13 +2107,3 @@ class MarstekCoordinator:
         else:
             # Normal mode: use configured interval
             return configured_interval
-
-    async def async_pause_control(self):
-        """Pause all control and set batteries to a safe state."""
-        _LOGGER.info("Battery control disabled. Setting all batteries to 0W and resetting state.")
-        async with self._update_lock:
-            await self._set_all_batteries_to_zero()
-            self._reset_pid_state()
-        # Reset internal state to ensure clean start when resuming
-        self._battery_priority = []
-        self._last_power_direction = PowerDir.NEUTRAL

--- a/custom_components/marstek_venus_ha/switch.py
+++ b/custom_components/marstek_venus_ha/switch.py
@@ -72,19 +72,24 @@ class ControlSwitch(SwitchEntity):
             _LOGGER.info("Battery control has been enabled.")
             self._data._control_enabled = True
             await self._data.async_save_settings()
+            self._data._battery_priority = []  # Clear battery priority to force recalculation on next update
+            self._data._last_power_direction = PowerDir.NEUTRAL  # Reset power direction to force recalculation
             self.async_write_ha_state()
             async_dispatcher_send(self.hass, SIGNAL_DIAGNOSTICS_UPDATED)
             if hasattr(self._data, "async_request_update"):
                 self.hass.async_create_task(self._data.async_request_update(reason="control_enabled"))
+            await self._data.async_start_listening()  # Start listening to updates when control is enabled
 
     async def async_turn_off(self, **kwargs):
         """Turn the switch off."""
         if self._data._control_enabled:
             self._data._control_enabled = False
             await self._data.async_save_settings()
+            self._data._battery_priority = []  # Clear battery priority to force recalculation on next update
+            self._data._last_power_direction = PowerDir.NEUTRAL  # Reset power direction to force recalculation
             self.async_write_ha_state()
             async_dispatcher_send(self.hass, SIGNAL_DIAGNOSTICS_UPDATED)
-            await self._data.async_pause_control()
+            await self._data.async_stop_listening()  # Stop listening to updates when control is disabled
 
 class ChargingSwitch(SwitchEntity):
     def __init__(self, entry: ConfigEntry, data_object: MarstekCoordinator):


### PR DESCRIPTION
Clear cached state and improve control enable/disable handling. On unload, clear the service call cache; when control is disabled the coordinator now returns early, resets battery priority and last power direction, and sets all batteries to 0W to avoid unnecessary processing. The switch now clears battery priority and power direction when toggled, starts listeners on enable (async_start_listening) and stops them on disable (async_stop_listening), and triggers an immediate update when enabling. Also removed the old async_pause_control helper and cleaned up a few logging formatting whitespace issues.