### PR TITLE
Use 'standby' option and bump version

### DIFF
--- a/custom_components/marstek_venus_ha/coordinator.py
+++ b/custom_components/marstek_venus_ha/coordinator.py
@@ -2042,8 +2042,8 @@ class MarstekCoordinator:
                     "select_option",
                     force_mode,
                     "option",
-                    "stop",
-                    {"entity_id": force_mode, "option": "stop"},
+                    "standby",
+                    {"entity_id": force_mode, "option": "standby"},
                     blocking=True,
                 )
 

--- a/custom_components/marstek_venus_ha/manifest.json
+++ b/custom_components/marstek_venus_ha/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "marstek_venus_ha",
   "name": "Marstek Venus Homeassistant Control",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "documentation": "https://github.com/diegoschlauri/marstek_venus_ha",
   "issue_tracker": "https://github.com/diegoschlauri/marstek_venus_ha/issues",
   "codeowners": ["@diegoschlauri","@sker65"],


### PR DESCRIPTION
Fix coordinator option for force_mode: call select_option with "standby" instead of "stop" to match the correct entity option from ViperRNMC Modbus 2026.6.1. Also bump manifest version to 2.1.2.