### PR TITLE
Use None default for battery max SOC entity

### DIFF
--- a/custom_components/marstek_venus_ha/config_flow.py
+++ b/custom_components/marstek_venus_ha/config_flow.py
@@ -333,7 +333,10 @@ class MarstekOptionsFlowHandler(config_entries.OptionsFlow):
         
             schema_dict[vol.Optional(
                 f"battery_{i}_max_soc_entity",
-                default=self._options.get(f"battery_{i}_max_soc_entity", self.config_entry.data.get(f"battery_{i}_max_soc_entity", ""))
+                default=self._options.get(
+                    f"battery_{i}_max_soc_entity",
+                    self.config_entry.data.get(f"battery_{i}_max_soc_entity", None),
+                ),
             )] = selector.EntitySelector(selector.EntitySelectorConfig(domain="number"))
 
             schema_dict[vol.Required(

--- a/custom_components/marstek_venus_ha/manifest.json
+++ b/custom_components/marstek_venus_ha/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "marstek_venus_ha",
   "name": "Marstek Venus Homeassistant Control",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "documentation": "https://github.com/diegoschlauri/marstek_venus_ha",
   "issue_tracker": "https://github.com/diegoschlauri/marstek_venus_ha/issues",
   "codeowners": ["@diegoschlauri","@sker65"],


### PR DESCRIPTION
Change the default for battery_{i}_max_soc_entity to use None when falling back to config_entry.data (instead of an empty string), and reformat the get() call for readability. This prevents an empty string from being treated as a valid default entity. Also bump package version in manifest.json from 2.3.0 to 2.3.1.