### PR TITLE
Initialize missing battery SOC fields

### DIFF
--- a/custom_components/marstek_venus_ha/config_flow.py
+++ b/custom_components/marstek_venus_ha/config_flow.py
@@ -312,6 +312,10 @@ class MarstekOptionsFlowHandler(config_entries.OptionsFlow):
         battery_count = self._options.get(CONF_BATTERY_COUNT, self.config_entry.data.get(CONF_BATTERY_COUNT, 1))
 
         if user_input is not None:
+            for i in range(1, battery_count + 1):
+                field_name = f"battery_{i}_max_soc_entity"
+                if field_name not in user_input:
+                    user_input[field_name] = None
             self._options.update(user_input)
             if self._all_mode:
                 return await self.async_step_wallbox()


### PR DESCRIPTION
Ensure all battery_<i>_max_soc_entity keys are present in options flow input. Before updating _options, iterate from 1..battery_count and set any missing battery_n_max_soc_entity fields to null (None) so downstream steps have a consistent option structure and won't fail on missing keys.