### PR TITLE
Normalize empty battery SOC entity fields

### DIFF
--- a/custom_components/marstek_venus_ha/config_flow.py
+++ b/custom_components/marstek_venus_ha/config_flow.py
@@ -129,6 +129,10 @@ class MarstekConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         battery_count = self._data.get(CONF_BATTERY_COUNT, 1)
         
         if user_input is not None:
+            for i in range(1, battery_count + 1):
+                field_name = f"battery_{i}_max_soc_entity"
+                if field_name not in user_input or user_input.get(field_name) in ("", None):
+                    user_input[field_name] = None
             self._data.update(user_input)
             return await self.async_step_wallbox()
         
@@ -314,7 +318,7 @@ class MarstekOptionsFlowHandler(config_entries.OptionsFlow):
         if user_input is not None:
             for i in range(1, battery_count + 1):
                 field_name = f"battery_{i}_max_soc_entity"
-                if field_name not in user_input:
+                if field_name not in user_input or user_input.get(field_name) in ("", None):
                     user_input[field_name] = None
             self._options.update(user_input)
             if self._all_mode:


### PR DESCRIPTION
Treat battery_<i>_max_soc_entity fields with blank or None values as explicit None in both the config flow and options flow. Iterate over the configured battery_count and replace missing or empty-string values with None before updating stored data/options to avoid persisting empty strings.