### PR TITLE
Initialize option for empty battery SOC fields

### DIFF
--- a/custom_components/marstek_venus_ha/config_flow.py
+++ b/custom_components/marstek_venus_ha/config_flow.py
@@ -318,8 +318,9 @@ class MarstekOptionsFlowHandler(config_entries.OptionsFlow):
         if user_input is not None:
             for i in range(1, battery_count + 1):
                 field_name = f"battery_{i}_max_soc_entity"
-                if field_name not in user_input or user_input.get(field_name) in ("", None):
+                if field_name not in user_input or not user_input.get(field_name):
                     user_input[field_name] = None
+                    self._options[field_name] = None
             self._options.update(user_input)
             if self._all_mode:
                 return await self.async_step_wallbox()


### PR DESCRIPTION
Treat any falsy battery_{i}_max_soc_entity as empty and explicitly clear it in self._options. The emptiness check was simplified to use a falsy test and self._options[field_name] is set to None before merging user_input so cleared fields don't retain previous values.