### PR TITLE
Use suggested_value and fix empty check

### DIFF
--- a/custom_components/marstek_venus_ha/config_flow.py
+++ b/custom_components/marstek_venus_ha/config_flow.py
@@ -318,7 +318,7 @@ class MarstekOptionsFlowHandler(config_entries.OptionsFlow):
         if user_input is not None:
             for i in range(1, battery_count + 1):
                 field_name = f"battery_{i}_max_soc_entity"
-                if field_name not in user_input or not user_input.get(field_name):
+                if field_name not in user_input or user_input.get(field_name) in ("", None):
                     user_input[field_name] = None
                     self._options[field_name] = None
             self._options.update(user_input)
@@ -339,13 +339,15 @@ class MarstekOptionsFlowHandler(config_entries.OptionsFlow):
                 f"battery_{i}_soc_entity",
                 default=self._options.get(f"battery_{i}_soc_entity", self.config_entry.data.get(f"battery_{i}_soc_entity", ""))
             )] = selector.EntitySelector(selector.EntitySelectorConfig(domain="sensor"))
-        
+
+            current_val = self._options.get(
+                f"battery_{i}_max_soc_entity",
+                self.config_entry.data.get(f"battery_{i}_max_soc_entity")
+            )
+
             schema_dict[vol.Optional(
                 f"battery_{i}_max_soc_entity",
-                default=self._options.get(
-                    f"battery_{i}_max_soc_entity",
-                    self.config_entry.data.get(f"battery_{i}_max_soc_entity", None),
-                ),
+                description={"suggested_value": current_val} if current_val else {}
             )] = selector.EntitySelector(selector.EntitySelectorConfig(domain="number"))
 
             schema_dict[vol.Required(


### PR DESCRIPTION
Avoid treating all falsy values as missing in the options flow by only normalizing empty string or None to None (so valid falsy values like 0 aren't overwritten). For the battery max SOC entity field, stop using a default value and instead expose the existing value via description.suggested_value (computed into current_val) so the UI shows the current selection without forcing a default. Minor whitespace cleanup.